### PR TITLE
Clearified step 3

### DIFF
--- a/docs/Contribution.md
+++ b/docs/Contribution.md
@@ -12,7 +12,7 @@ Because the _UI5 Journey Recorder_ is a Chrome Extension the Chrome-Webbrowser i
 
 ##  set up the dev environment
 1. Clone the repo from [Github](https://github.com/ui5-community/ui5-journey-recorder.git)
-2. Navigate to the app folder of the repository
+2. Navigate to the app folder of the repository and install the dependencies `npm install`
 3. Execute the watch-NPM-Script `npm run watch`
 4. Open Chrome and the [Chrome-Extension Page](chrome://extensions)
 5. Choose the "Load unpacked" Button in the top left


### PR DESCRIPTION
To be able to execute npm run watch in step 4, the dependencies must be installed before, e.g. in step 3 via npm install